### PR TITLE
Fix Session Fixtures Without Id

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changelog
 Version 0.2
 -----------
 
-- https://github.com/dlr-sp/pytest-isolate-mpi/pull/14 fixes an edge case when using session scoped fixtures on non-parametrized tests.
+- An unhandled edge case when using a session-scoped fixture in
+  non-parametrized tests was fixed. (`#14`_)
+
+.. _#14:  https://github.com/dlr-sp/pytest-isolate-mpi/pull/14
 
 Version 0.1
 -----------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Version 0.2
+-----------
+
+- https://github.com/dlr-sp/pytest-isolate-mpi/pull/14 fixes an edge case when using session scoped fixtures on non-parametrized tests.
+
 Version 0.1
 -----------
 

--- a/src/pytest_isolate_mpi/_fixturecache.py
+++ b/src/pytest_isolate_mpi/_fixturecache.py
@@ -50,7 +50,10 @@ def _get_identifier(fixturedef: FixtureDef, request: SubRequest) -> str:
     # all the fixtures
     fixturedefs: dict[str, FixtureDef] = {arg: f[0] for arg, f in request._arg2fixturedefs.items() if arg != "request"}
     # the test's parametrization as dictionary of indices:
-    test_indices: dict[str, int] = request._pyfuncitem.callspec.indices
+    if hasattr(request._pyfuncitem, 'callspec'):
+        test_indices: dict[str, int] = request._pyfuncitem.callspec.indices
+    else:
+        test_indices: dict[str, int] = {}
     fixture_name: str = fixturedef.argname  # this fixture's name
 
     def get_dependent_names(fixturedef: FixtureDef) -> list[str]:


### PR DESCRIPTION
If a test uses only fixtures without ids -- that cannot happen if the `"mpi_ranks"` fixture is used -- `_get_identifier` previously raised an `AttributeError` because `callspec` was not found.