### PR TITLE
Options for MPI Executable in Ini-File

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -116,23 +116,25 @@ mpi_executable
     none is given, ``pytest-isolate-mpi`` tries ``mpirun`` and
     ``mpiexec``.
 
-mpi_flag_for_processes
-    The command line flag of the MPI executable indicating the number of
+mpi_option_for_processes
+    The command line option of the MPI executable indicating the number of
     processes, such that ``pytest-isolate-mpi`` can launch the MPI
-    environement with the appropriate number of processes as defined in
+    environment with the appropriate number of processes as defined in
     the ``mpi`` mark. Defaults to ``-n``.
 
-mpi_command_line_inputs
-    Additional command line inputs to run the MPI executable with.
+mpi_command_line_args
+    Additional command line arguments to run the MPI executable with.
     By default, none are given.
 
-For example, the ``pytest.ini`` for execution on HPC clusters with Slurm
-could be::
+For example, the following ``pytest.ini`` will result in tests marked
+with ``@pytest.mark.mpi(ranks=2)`` to be launched by Slrum's ``srun`` on
+two compute nodes with 128 processes each.
 
 
     # pytest.ini
     mpi_executable = srun
-    mpi_command_line_inputs = -N 2 --account MySlrumAccount
+    mpi_option_for_processes = -N
+    mpi_command_line_args = --ntasks-per-node 128 --account <MySlrumAccount>
 
 
 When running Slurm with multiple compute nodes, make sure that ``$TMPDIR``

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -105,6 +105,38 @@ mpi_tmp_path
     See also :func:`pytest_isolate_mpi.fixtures.mpi_tmp_path_fixture`.
 
 
+Configuration
+-------------
+
+``pytest-isolate-mpi`` can be configured through the ``pytest`` 
+`configuration file`_:
+
+mpi_executable
+    The mpi executable to launch the forked MPI environment with. If 
+    none is given, ``pytest-isolate-mpi`` tries ``mpirun`` and 
+    ``mpiexec``.
+
+mpi_flag_for_processes
+    The command line flag of the MPI executable indicating the number of
+    processes, such that ``pytest-isolate-mpi`` can launch the MPI 
+    environement with the appropriate number of processes as defined in 
+    the ``mpi`` mark. Defaults to ``-n``.
+
+mpi_command_line_inputs
+    Additional command line inputs to run the MPI executable with.
+    By default, none are given.
+
+For example, the ``pytest.ini`` for execution on HPC clusters with Slurm
+could be::
+
+
+    # pytest.ini
+    mpi_executable = srun
+    mpi_command_line_inputs = -N 2 --account MySlrumAccount
+
+.. _configuration file: https://docs.pytest.org/en/stable/how-to/fixtures.html#fixture-scopes
+
+
 Limitations
 -----------
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -108,18 +108,18 @@ mpi_tmp_path
 Configuration
 -------------
 
-``pytest-isolate-mpi`` can be configured through the ``pytest`` 
+``pytest-isolate-mpi`` can be configured through the ``pytest``
 `configuration file`_:
 
 mpi_executable
-    The mpi executable to launch the forked MPI environment with. If 
-    none is given, ``pytest-isolate-mpi`` tries ``mpirun`` and 
+    The mpi executable to launch the forked MPI environment with. If
+    none is given, ``pytest-isolate-mpi`` tries ``mpirun`` and
     ``mpiexec``.
 
 mpi_flag_for_processes
     The command line flag of the MPI executable indicating the number of
-    processes, such that ``pytest-isolate-mpi`` can launch the MPI 
-    environement with the appropriate number of processes as defined in 
+    processes, such that ``pytest-isolate-mpi`` can launch the MPI
+    environement with the appropriate number of processes as defined in
     the ``mpi`` mark. Defaults to ``-n``.
 
 mpi_command_line_inputs
@@ -133,6 +133,11 @@ could be::
     # pytest.ini
     mpi_executable = srun
     mpi_command_line_inputs = -N 2 --account MySlrumAccount
+
+
+When running Slurm with multiple compute nodes, make sure that ``$TMPDIR``
+is set to a single directory outside the compute nodes, e.g a directory on
+on ``/scratch`` or ``/lustre``.
 
 .. _configuration file: https://docs.pytest.org/en/stable/how-to/fixtures.html#fixture-scopes
 

--- a/examples/pytest.ini
+++ b/examples/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+mpi_command_line_inputs=--bind-to core -x foo=bar

--- a/examples/pytest.ini
+++ b/examples/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-mpi_command_line_inputs=--bind-to core -x foo=bar
+mpi_command_line_args=--bind-to core -x foo=bar

--- a/examples/test_mpi_command_line_inputs.py
+++ b/examples/test_mpi_command_line_inputs.py
@@ -1,0 +1,10 @@
+import os
+
+import pytest
+
+
+@pytest.mark.mpi(ranks=2)
+def test_with_mpi(mpi_ranks):  # pylint: disable=unused-argument
+    """This test checks whether command line arguments to the mpi executable, as given in the ini-file,
+    are passed correctly"""
+    assert os.getenv("foo") == "bar"

--- a/src/pytest_isolate_mpi/_plugin.py
+++ b/src/pytest_isolate_mpi/_plugin.py
@@ -199,6 +199,12 @@ class MPIPlugin:
                 report.location = fspath, lineno, f"{domain}[rank={comm.rank}]"
                 report.nodeid = f"{report.nodeid}[rank={comm.rank}]"
             setattr(report, "rank", comm.rank)
+        if not os.path.isdir(os.environ["PYTEST_MPI_REPORTS_PATH"]):
+            raise RuntimeError(
+                "Could not find temporary directory. If you are using SLURM running on multiple compute nodes, this is "
+                "likely because each node has its own local `/tmp`. Try setting `$TMPDIR` to a single directory "
+                "outside the compute nodes."
+            )
         with open(os.path.join(os.environ["PYTEST_MPI_REPORTS_PATH"], f"{comm.rank}"), mode="wb") as f:
             pickle.dump(reports, f)
         return reports

--- a/src/pytest_isolate_mpi/_plugin.py
+++ b/src/pytest_isolate_mpi/_plugin.py
@@ -47,7 +47,7 @@ class MPIConfiguration:
             flag_for_processes="-n",
             mpi_command_line_inputs: list[str] = None
     ):
-        if mpi_executable is None:
+        if not mpi_executable:
             self.mpirun_executable = self.__get_mpirun_executable()
         else:
             if shutil.which(mpi_executable) is None:
@@ -326,7 +326,7 @@ def pytest_configure(config):
 
 def pytest_addoption(parser):
     """
-    Add pytest-mpi options to pytest cli
+    Add pytest-mpi options to pytest cli and ini file
     """
     group = parser.getgroup("mpi", description="support for MPI-enabled code")
     group.addoption(

--- a/src/pytest_isolate_mpi/_plugin.py
+++ b/src/pytest_isolate_mpi/_plugin.py
@@ -48,7 +48,7 @@ class MPIConfiguration:
             mpi_command_line_inputs: list[str] = None
     ):
         if not mpi_executable:
-            self.mpirun_executable = self.__get_mpirun_executable()
+            self.mpirun_executable = self.__deduce_mpirun_executable()
         else:
             if shutil.which(mpi_executable) is None:
                 pytest.exit(f"failed to find mpi executable {mpi_executable} as defined in ini-file.",
@@ -74,7 +74,7 @@ class MPIConfiguration:
         return parallel_cmd
 
     @staticmethod
-    def __get_mpirun_executable() -> str:
+    def __deduce_mpirun_executable() -> str:
         if shutil.which("mpirun") is not None:
             return "mpirun"
         elif shutil.which("mpiexec") is not None:

--- a/src/pytest_isolate_mpi/_plugin.py
+++ b/src/pytest_isolate_mpi/_plugin.py
@@ -37,25 +37,25 @@ from .fixtures import mpi_tmp_path_fixture  # pylint: disable=unused-import
 class MPIConfiguration:
     """Configuration defining how to execute an MPI-parallel subprocess"""
 
-    mpirun_executable: str
-    flag_for_processes: str
-    mpirun_command_line_inputs: list[str]
+    mpi_executable: str
+    mpi_option_for_processes: str
+    mpi_command_line_arguments: list[str]
 
     def __init__(
             self,
             mpi_executable: str = None,
-            flag_for_processes="-n",
-            mpi_command_line_inputs: list[str] = None
+            mpi_option_for_processes="-n",
+            mpi_command_line_args: list[str] = None
     ):
         if not mpi_executable:
-            self.mpirun_executable = self.__deduce_mpirun_executable()
+            self.mpi_executable = self.__deduce_mpirun_executable()
         else:
             if shutil.which(mpi_executable) is None:
                 pytest.exit(f"failed to find mpi executable {mpi_executable} as defined in ini-file.",
                             pytest.ExitCode.USAGE_ERROR)
-            self.mpirun_executable = mpi_executable
-        self.flag_for_processes = flag_for_processes
-        self.mpirun_command_line_inputs = mpi_command_line_inputs if mpi_command_line_inputs else []
+            self.mpi_executable = mpi_executable
+        self.mpi_option_for_processes = mpi_option_for_processes
+        self.mpi_command_line_arguments = mpi_command_line_args if mpi_command_line_args else []
 
     def extend_command_for_parallel_execution(
         self, cmd: list[str], ranks: int
@@ -63,11 +63,11 @@ class MPIConfiguration:
         """Extend a given command sequence by the mpirun call for the given number of ranks."""
         parallel_cmd = (
             [
-                self.mpirun_executable,
-                self.flag_for_processes,
+                self.mpi_executable,
+                self.mpi_option_for_processes,
                 str(ranks),
             ]
-            + self.mpirun_command_line_inputs
+            + self.mpi_command_line_arguments
             + cmd
         )
 
@@ -113,8 +113,8 @@ class MPIPlugin:
 
         self._mpi_configuration = MPIConfiguration(
             mpi_executable=config.getini("mpi_executable"),
-            flag_for_processes=config.getini("mpi_flag_for_processes"),
-            mpi_command_line_inputs=config.getini("mpi_command_line_inputs")
+            mpi_option_for_processes=config.getini("mpi_option_for_processes"),
+            mpi_command_line_args=config.getini("mpi_command_line_args")
         )
 
         # double check whether MPI environment variables are residing in the forked env
@@ -340,7 +340,7 @@ def pytest_addoption(parser):
     )
     parser.addini("mpi_executable", type="string", default=None,
                   help="mpi executable (e.g. 'mpirun', 'mpiexec', 'srun')")
-    parser.addini("mpi_flag_for_processes", type="string", default="-n",
-                  help="mpi flag for number of processes ('-n')")
-    parser.addini("mpi_command_line_inputs", type="args", default=None,
-                  help="mpi command line inputs (e.g. '--bind-to core')")
+    parser.addini("mpi_option_for_processes", type="string", default="-n",
+                  help="mpi option for number of processes ('-n')")
+    parser.addini("mpi_command_line_args", type="args", default=None,
+                  help="mpi command line arguments (e.g. '--bind-to core')")


### PR DESCRIPTION
Added entries
* `mpi_executable`, e.g. `mpirun`,
* `mpi_flag_for_processes`, e.g. `-n`, and 
* `mpi_command_line_inputs`, e.g. `--bind-to core`

to pytest's ini-file.