### PR TITLE
Try to Fix the Docs on RTD.io

### DIFF
--- a/examples/pytest.ini
+++ b/examples/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-mpi_command_line_args=--bind-to core -x foo=bar
+mpi_command_line_args=--bind-to core:overload-allowed -x foo=bar


### PR DESCRIPTION
It seems that passing `--bind core` overrides the environment variable we set to allow oversubscribing MPI runs. Remember, docs are built with only a single CPU core available.

This did the trick, see https://pytest-isolate-mpi.readthedocs.io/en/fix-doc-logs/usage.html