### PR TITLE
Fix license detection

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 BSD 3-Clause License
 
-Copyright 2024 German Aerospace Center (DLR e.V.) - Institute of
-Software Methods for Product Virtualization
+Copyright (c) 2024, German Aerospace Center (DLR e.V.) - Institute of
+                    Software Methods for Product Virtualization
 Copyright (c) 2016, James Tocknell
 
 Redistribution and use in source and binary forms, with or without

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2024, German Aerospace Center (DLR e.V.) - Institute of
-                    Software Methods for Product Virtualization
+Copyright (c) 2024, German Aerospace Center (DLR e.V.)
 Copyright (c) 2016, James Tocknell
 
 Redistribution and use in source and binary forms, with or without
@@ -28,4 +27,3 @@ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-

--- a/README.rst
+++ b/README.rst
@@ -47,8 +47,8 @@ instructions on how to contribute to ``pytest-isolate-mpi``.
 License
 -------
 
-This work is licensed under the conditions of the BSD license, see
-`LICENSE <LICENSE>`_.
+This work is licensed under the conditions of the BSD-3-Clause license,
+see `LICENSE <LICENSE>`_.
 
 The software is provided as is.  We sincerely welcome your feedback on
 issues, bugs and possible improvements.  Please use the issue tracker of


### PR DESCRIPTION
This time, I checked with the [licensee](https://github.com/licensee/licensee) tool Github is using. The BSD 3 clause license is now picked up as intended. 

Fixes #26 