### PR TITLE
Implement Global Test Timouts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,15 @@ Changelog
 Version 0.3
 -----------
 
-- Add a command line option to disable MPI and/or process isolation to
-  make the debugging of MPI-parallel test cases easier.
+- A command line option to disable MPI and/or process isolation has been
+  added. This particularly useful to debug MPI-parallel test cases.
+  (`#24`_)
+
+- Command line options to set a default test timeout and test timeout
+  unit for all MPI-parallel tests have been added. (`#20`_)
+
+.. _#20: https://github.com/dlr-sp/pytest-isolate-mpi/issues/20
+.. _#24: https://github.com/dlr-sp/pytest-isolate-mpi/issues/24
 
 Version 0.2
 -----------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -58,6 +58,8 @@ produced:
 .. literalinclude:: ../examples/test_number_of_processes_matches_ranks.py.out
     :language: output
 
+.. _timeouts:
+
 Enforcing a Maximum Runtime for MPI Tests
 -----------------------------------------
 
@@ -123,6 +125,19 @@ following command line arguments to ``pytest``:
 --verbose-mpi
     Include detailed MPI information in output.
 
+
+--mpi-default-test-timeout
+    Sets a default test timeout for all MPI-isolated tests. This timeout
+    can be overriden per test via the the ``timeout`` argument of the
+    ``mpi`` marker, see :ref:`timeouts`. Defaults to no timeout if not
+    specified.
+
+--mpi-default-test-timeout-unit
+    Sets a default test timeout unit for all MPI-isolated tests. This
+    timeout can be overriden per test via the the ``unit`` argument of
+    the ``mpi`` marker, see :ref:`timeouts`. Defaults to ``s`` for
+    seconds if not specified. The other valid choices are ``m`` for
+    minutes and ``h`` for hours.
 
 
 Configuration

--- a/src/pytest_isolate_mpi/_constants.py
+++ b/src/pytest_isolate_mpi/_constants.py
@@ -16,6 +16,8 @@ class MPIMarkerEnum(str, enum.Enum):
 
 VERBOSE_MPI_ARG = "--verbose-mpi"
 NO_MPI_ISOLATION_ARG = "--no-mpi-isolation"
+MPI_DEFAULT_TEST_TIMEOUT_ARG = "--mpi-default-test-timeout"
+MPI_DEFAULT_TEST_TIMEOUT_UNIT_ARG = "--mpi-default-test-timeout-unit"
 ENVIRONMENT_VARIABLE_TO_HIDE_INNARDS_OF_PLUGIN = "PYTEST_ISOLATE_MPI_IS_FORKED"
 TIME_UNIT_CONVERSION = {
     "s": lambda timeout: timeout,


### PR DESCRIPTION
So users can set a catch-all timeout for all MPI-parallel tests.

Fixes #20 