### PR TITLE
Fix installation command for pytest-isolate-mpi

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,7 +4,7 @@ Installation
 ``pytest-isolate-mpi`` is available on `pypi.org`_ and can be installed
 with ``pip``::
 
-    pip install pytest-mpi-isolate
+    pip install pytest-isolate-mpi
 
 
 .. _pypi.org: https://pypi.org/project/pytest-isolate-mpi/


### PR DESCRIPTION
I noticed that the install command in the documentation used the wrong package name.