### PR TITLE
pytest 9.1 compatibility

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
-        pytest-version: ["7.3", "7.4", "8.0", "8.1", "8.2", "8.3"]
+        python-version: ["3.10", "3.11", "3.12"]
+        pytest-version: ["7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "9.0", "9.1"]
     steps:
     - uses: actions/checkout@v4
     - name: Install OpenMPI

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,15 @@ Changelog
 
 Version 0.4
 -----------
+- Compatibility with Pytest >= 9.1 has been restored. Session-scoped
+  fixtures whose result cannot be pickled (such as Pytest's
+  ``tmp_path_factory``, which is no longer picklable since Pytest 9.1) are
+  now skipped by the fixture cache and re-evaluated in each subsession,
+  instead of crashing the run. The cache file is only created once the
+  fixture result has been serialized successfully, so a failed write can no
+  longer leave a truncated file behind that would make subsequent
+  subsessions fail with ``EOFError``. (`#36`_)
+
 - The ``mpi`` marker now accepts an optional ``threads`` argument. 
   When set, ``OMP_NUM_THREADS`` is configured for each isolated MPI process.
 
@@ -12,15 +21,8 @@ Version 0.4
   allowing a main session outside of a container to spawn containerized
   subsessions. (`#33`_)
 
-- Compatibility with Pytest >= 9.1 has been restored. Session-scoped
-  fixtures whose result cannot be pickled (such as Pytest's
-  ``tmp_path_factory``, which is no longer picklable since Pytest 9.1) are
-  now skipped by the fixture cache and re-evaluated in each subsession,
-  instead of crashing the run. The cache is also written atomically, so a
-  failed write can no longer leave a truncated file behind that would make
-  subsequent subsessions fail with ``EOFError``.
-
 .. _#33:  https://github.com/dlr-sp/pytest-isolate-mpi/pull/33
+.. _#36:  https://github.com/dlr-sp/pytest-isolate-mpi/pull/36
 
 Version 0.3
 -----------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,14 +3,16 @@ Changelog
 
 Version 0.4
 -----------
-- Compatibility with Pytest >= 9.1 has been restored. Session-scoped
-  fixtures whose result cannot be pickled (such as Pytest's
-  ``tmp_path_factory``, which is no longer picklable since Pytest 9.1) are
-  now skipped by the fixture cache and re-evaluated in each subsession,
-  instead of crashing the run. The cache file is only created once the
-  fixture result has been serialized successfully, so a failed write can no
-  longer leave a truncated file behind that would make subsequent
-  subsessions fail with ``EOFError``. (`#36`_)
+- Compatibility with Pytest >= 9.1 has been restored. Pytest's
+  ``tmp_path_factory``, which is no longer picklable since Pytest 9.1, is
+  serialized with a dedicated recipe so it remains cached and all
+  subsessions keep sharing one base temporary directory. Session-scoped
+  fixtures whose result still cannot be pickled are skipped by the fixture
+  cache and re-evaluated in each subsession, instead of crashing the run.
+  The cache file is only created once the fixture result has been
+  serialized successfully, so a failed write can no longer leave a
+  truncated file behind that would make subsequent subsessions fail with
+  ``EOFError``. (`#36`_)
 
 - The ``mpi`` marker now accepts an optional ``threads`` argument. 
   When set, ``OMP_NUM_THREADS`` is configured for each isolated MPI process.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,14 @@ Version 0.4
   allowing a main session outside of a container to spawn containerized
   subsessions. (`#33`_)
 
+- Compatibility with Pytest >= 9.1 has been restored. Session-scoped
+  fixtures whose result cannot be pickled (such as Pytest's
+  ``tmp_path_factory``, which is no longer picklable since Pytest 9.1) are
+  now skipped by the fixture cache and re-evaluated in each subsession,
+  instead of crashing the run. The cache is also written atomically, so a
+  failed write can no longer leave a truncated file behind that would make
+  subsequent subsessions fail with ``EOFError``.
+
 .. _#33:  https://github.com/dlr-sp/pytest-isolate-mpi/pull/33
 
 Version 0.3

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,10 @@ Version 0.4
   truncated file behind that would make subsequent subsessions fail with
   ``EOFError``. (`#36`_)
 
-- The ``mpi`` marker now accepts an optional ``threads`` argument. 
+- Python 3.10 or newer and Pytest 7.3 or newer are now required, matching
+  the versions covered by the CI test matrix.
+
+- The ``mpi`` marker now accepts an optional ``threads`` argument.
   When set, ``OMP_NUM_THREADS`` is configured for each isolated MPI process.
 
 - Two command line options for the use of independent Python executables

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -254,6 +254,13 @@ default ``function`` scope is limited for MPI-parallel tests:
   Fixtures are serialized with the :mod:`pickle` module. Please note that
   not all Python objects support pickling.
 
+  A session-scoped fixture whose result cannot be pickled is skipped
+  by the cache rather than failing the test run. Such a fixture is
+  re-evaluated in every sub session, as the ``comm`` fixture is, and
+  thus effectively behaves as if it were function-scoped: any state
+  it holds is not shared between MPI-parallel tests. Pytest's own
+  ``tmp_path_factory`` is one such fixture as of Pytest 9.1.
+
 * ``class``, ``module``, and ``package``: Fixtures for these scopes are
   re-created for each MPI-parallel tests. Such fixtures effectively
   behave as if they were function-scoped.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -252,14 +252,16 @@ default ``function`` scope is limited for MPI-parallel tests:
   caches its own dedicated fixture. Sharing fixtures between tests of
   differently sized communicators and non-MPI/MPI tests is not possible.
   Fixtures are serialized with the :mod:`pickle` module. Please note that
-  not all Python objects support pickling.
+  not all Python objects support pickling. Pytest's own ``tmp_path_factory``
+  holds unpicklable cleanup machinery since Pytest 9.1; the cache serializes
+  it with a dedicated recipe so all sub sessions keep sharing one base
+  temporary directory.
 
-  A session-scoped fixture whose result cannot be pickled is skipped
-  by the cache rather than failing the test run. Such a fixture is
+  Any other session-scoped fixture whose result cannot be pickled is
+  skipped by the cache rather than failing the test run. Such a fixture is
   re-evaluated in every sub session, as the ``comm`` fixture is, and
   thus effectively behaves as if it were function-scoped: any state
-  it holds is not shared between MPI-parallel tests. Pytest's own
-  ``tmp_path_factory`` is one such fixture as of Pytest 9.1.
+  it holds is not shared between MPI-parallel tests.
 
 * ``class``, ``module``, and ``package``: Fixtures for these scopes are
   re-created for each MPI-parallel tests. Such fixtures effectively

--- a/examples/test_tmp_path_factory_cached.py
+++ b/examples/test_tmp_path_factory_cached.py
@@ -1,0 +1,18 @@
+import pytest
+
+# Each test below runs in its own subsession. The first subsession stores the
+# session-scoped ``tmp_path_factory`` in the fixture cache; the second only
+# sees the same base temporary directory if the factory was restored from the
+# cache instead of being evaluated anew.
+
+
+@pytest.mark.mpi(ranks=2)
+def test_tmp_path_factory_is_cached(mpi_ranks, comm, tmp_path_factory):  # pylint: disable=unused-argument
+    marker = tmp_path_factory.getbasetemp() / f"marker-rank-{comm.rank}"
+    marker.touch()
+    assert marker.exists()
+
+
+@pytest.mark.mpi(ranks=2)
+def test_tmp_path_factory_is_shared(mpi_ranks, comm, tmp_path_factory):  # pylint: disable=unused-argument
+    assert (tmp_path_factory.getbasetemp() / f"marker-rank-{comm.rank}").exists()

--- a/examples/test_unpicklable_session_fixture.py
+++ b/examples/test_unpicklable_session_fixture.py
@@ -1,3 +1,14 @@
+# pylint: disable=unused-argument,redefined-outer-name
+"""Session fixtures whose values cannot be pickled are not cached across
+subsessions but re-evaluated per test, like ``comm``.
+
+Each MPI test runs in its own forked subsession, so this scenario inherently
+needs two tests: the first exercises the cache write path (the plugin must
+skip caching the unpicklable value instead of crashing), the second exercises
+the cache read path in a later subsession (no cache file, so the fixture is
+evaluated again).
+"""
+
 import threading
 
 import pytest
@@ -5,15 +16,16 @@ import pytest
 
 @pytest.fixture(scope="session")
 def unpicklable():
-    return threading.Lock()
+    return threading.Lock()  # locks cannot be pickled
 
 
 @pytest.mark.mpi(ranks=2)
-def test_uses_unpicklable_first(mpi_ranks, comm, unpicklable):  # pylint: disable=unused-argument,redefined-outer-name
+def test_unpicklable_fixture_is_not_cached(mpi_ranks, comm, unpicklable):
+    # First subsession: evaluates the fixture, the plugin skips caching it.
     assert unpicklable is not None
 
 
 @pytest.mark.mpi(ranks=2)
-def test_uses_unpicklable_second(mpi_ranks, comm, unpicklable):  # pylint: disable=unused-argument,redefined-outer-name
-    # Runs in a separate subsession and would load the cached fixture result.
+def test_unpicklable_fixture_is_reevaluated(mpi_ranks, comm, unpicklable):
+    # Later subsession: finds no cache file and evaluates the fixture again.
     assert unpicklable is not None

--- a/examples/test_unpicklable_session_fixture.py
+++ b/examples/test_unpicklable_session_fixture.py
@@ -1,4 +1,3 @@
-# pylint: disable=unused-argument,redefined-outer-name
 import threading
 
 import pytest
@@ -10,12 +9,14 @@ def unpicklable():
 
 
 @pytest.mark.mpi(ranks=2)
-def test_unpicklable_fixture_is_not_cached(mpi_ranks, comm, unpicklable):
+@pytest.mark.usefixtures("unpicklable")
+def test_unpicklable_fixture_is_not_cached(mpi_ranks, comm):
     # First subsession: evaluates the fixture, the plugin skips caching it.
-    assert unpicklable is not None
+    assert comm.size == mpi_ranks
 
 
 @pytest.mark.mpi(ranks=2)
-def test_unpicklable_fixture_is_reevaluated(mpi_ranks, comm, unpicklable):
+@pytest.mark.usefixtures("unpicklable")
+def test_unpicklable_fixture_is_reevaluated(mpi_ranks, comm):
     # Later subsession: finds no cache file and evaluates the fixture again.
-    assert unpicklable is not None
+    assert comm.size == mpi_ranks

--- a/examples/test_unpicklable_session_fixture.py
+++ b/examples/test_unpicklable_session_fixture.py
@@ -1,14 +1,4 @@
 # pylint: disable=unused-argument,redefined-outer-name
-"""Session fixtures whose values cannot be pickled are not cached across
-subsessions but re-evaluated per test, like ``comm``.
-
-Each MPI test runs in its own forked subsession, so this scenario inherently
-needs two tests: the first exercises the cache write path (the plugin must
-skip caching the unpicklable value instead of crashing), the second exercises
-the cache read path in a later subsession (no cache file, so the fixture is
-evaluated again).
-"""
-
 import threading
 
 import pytest

--- a/examples/test_unpicklable_session_fixture.py
+++ b/examples/test_unpicklable_session_fixture.py
@@ -8,15 +8,22 @@ def unpicklable():
     return threading.Lock()  # locks cannot be pickled
 
 
+# The two tests below share one cache file, since its path is keyed by the fixture name
+# and the size/rank combination rather than by the test. Each runs in its own subsession,
+# so in order they cover the write side of the cache and then the read side.
+
+
 @pytest.mark.mpi(ranks=2)
 @pytest.mark.usefixtures("unpicklable")
 def test_unpicklable_fixture_is_not_cached(mpi_ranks, comm):
-    # First subsession: evaluates the fixture, the plugin skips caching it.
+    # Write side: the fixture is evaluated, pickling its result fails, and the plugin
+    # skips caching instead of failing the run.
     assert comm.size == mpi_ranks
 
 
 @pytest.mark.mpi(ranks=2)
 @pytest.mark.usefixtures("unpicklable")
 def test_unpicklable_fixture_is_reevaluated(mpi_ranks, comm):
-    # Later subsession: finds no cache file and evaluates the fixture again.
+    # Read side, one subsession later: with no cache file to load, the fixture is simply
+    # evaluated again. Fails with an EOFError if the skipped write left an empty file.
     assert comm.size == mpi_ranks

--- a/examples/test_unpicklable_session_fixture.py
+++ b/examples/test_unpicklable_session_fixture.py
@@ -3,17 +3,17 @@ import threading
 import pytest
 
 
-@pytest.fixture(scope="session", name="unpicklable")
-def unpicklable_fixture():
+@pytest.fixture(scope="session")
+def unpicklable():
     return threading.Lock()
 
 
 @pytest.mark.mpi(ranks=2)
-def test_uses_unpicklable_first(mpi_ranks, comm, unpicklable):  # pylint: disable=unused-argument
+def test_uses_unpicklable_first(mpi_ranks, comm, unpicklable):  # pylint: disable=unused-argument,redefined-outer-name
     assert unpicklable is not None
 
 
 @pytest.mark.mpi(ranks=2)
-def test_uses_unpicklable_second(mpi_ranks, comm, unpicklable):  # pylint: disable=unused-argument
+def test_uses_unpicklable_second(mpi_ranks, comm, unpicklable):  # pylint: disable=unused-argument,redefined-outer-name
     # Runs in a separate subsession and would load the cached fixture result.
     assert unpicklable is not None

--- a/examples/test_unpicklable_session_fixture.py
+++ b/examples/test_unpicklable_session_fixture.py
@@ -1,0 +1,19 @@
+import threading
+
+import pytest
+
+
+@pytest.fixture(scope="session", name="unpicklable")
+def unpicklable_fixture():
+    return threading.Lock()
+
+
+@pytest.mark.mpi(ranks=2)
+def test_uses_unpicklable_first(mpi_ranks, comm, unpicklable):  # pylint: disable=unused-argument
+    assert unpicklable is not None
+
+
+@pytest.mark.mpi(ranks=2)
+def test_uses_unpicklable_second(mpi_ranks, comm, unpicklable):  # pylint: disable=unused-argument
+    # Runs in a separate subsession and would load the cached fixture result.
+    assert unpicklable is not None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 name = "pytest-isolate-mpi"
 description = "pytest-isolate-mpi allows for MPI-parallel tests being executed in a segfault and MPI_Abort safe manner"
 readme = "README.rst"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 license = {file = "LICENSE"}
 dynamic = ["version"]
 keywords = []
@@ -22,7 +22,7 @@ classifiers = [
   "Framework :: Pytest",
 ]
 dependencies = [
-    "pytest >= 5",
+    "pytest >= 7.3",
     "mpi4py",
 ]
 

--- a/src/pytest_isolate_mpi/_fixturecache.py
+++ b/src/pytest_isolate_mpi/_fixturecache.py
@@ -37,7 +37,10 @@ def _cache_fixture_result(fixturedef: FixtureDef, request: SubRequest):
             try:
                 payload = pickle.dumps(res)
 
-            # tmp_path_factory (>= 9.1), locks, open files, lambdas, ... aren't picklable.
+            # Pickling failures are not confined to pickle.PicklingError: Pytest's own
+            # tmp_path_factory raises AttributeError since Pytest 9.1, locks and open
+            # files raise TypeError, and a custom __reduce__ may raise anything at all.
+            # A fixture that cannot be cached must never fail the test run.
             except Exception:  # pylint: disable=broad-exception-caught
                 return  # skip caching; the fixture is re-evaluated in each subsession
 

--- a/src/pytest_isolate_mpi/_fixturecache.py
+++ b/src/pytest_isolate_mpi/_fixturecache.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import os
 import pickle
-import tempfile
 
 from _pytest.fixtures import FixtureDef
 from _pytest.fixtures import SubRequest
@@ -39,21 +38,12 @@ def _cache_fixture_result(fixturedef: FixtureDef, request: SubRequest):
                 payload = pickle.dumps(res)
 
             # tmp_path_factory (>= 9.1), locks, open files, lambdas, ... aren't picklable.
-            except (pickle.PicklingError, AttributeError, TypeError):
+            except Exception:  # pylint: disable=broad-exception-caught
                 return  # skip caching; the fixture is re-evaluated in each subsession
 
-            cache_dir = os.path.dirname(cache_file_path)
-            os.makedirs(cache_dir, exist_ok=True)
-            fd, tmp_path = tempfile.mkstemp(dir=cache_dir)
-            try:
-                with os.fdopen(fd, mode="wb") as f:
-                    f.write(payload)
-                os.replace(tmp_path, cache_file_path)
-            except BaseException:  # pylint: disable=broad-exception-caught
-                # Remove the temporary file on any error so we never leave a stray file behind.
-                if os.path.isfile(tmp_path):
-                    os.remove(tmp_path)
-                raise
+            os.makedirs(os.path.dirname(cache_file_path), exist_ok=True)
+            with open(cache_file_path, mode="wb") as f:
+                f.write(payload)
 
 
 def _get_cache_file_path(fixturedef: FixtureDef, request: SubRequest) -> str:

--- a/src/pytest_isolate_mpi/_fixturecache.py
+++ b/src/pytest_isolate_mpi/_fixturecache.py
@@ -34,7 +34,7 @@ class _CachePickler(pickle.Pickler):
         return NotImplemented
 
 
-def _dumps(obj) -> bytes:
+def _pickle_dumps(obj) -> bytes:
     """Pickles ``obj`` with the fixture-result recipes of ``_CachePickler``."""
     buffer = io.BytesIO()
     _CachePickler(buffer).dump(obj)
@@ -65,11 +65,9 @@ def _cache_fixture_result(fixturedef: FixtureDef, request: SubRequest):
         if not os.path.isfile(cache_file_path):
             res = fixturedef.cached_result[0]
             try:
-                payload = _dumps(res)
+                payload = _pickle_dumps(res)
 
-            # Pickling failures are not confined to pickle.PicklingError: locks and
-            # open files raise TypeError, and a custom __reduce__ may raise anything
-            # at all. A fixture that cannot be cached must never fail the test run.
+            # A fixture that cannot be cached must never fail the test run.
             except Exception:  # pylint: disable=broad-exception-caught
                 return  # skip caching; the fixture is re-evaluated in each subsession
 

--- a/src/pytest_isolate_mpi/_fixturecache.py
+++ b/src/pytest_isolate_mpi/_fixturecache.py
@@ -4,11 +4,41 @@ Functionalities for caching fixture results across MPI-sessions.
 
 from __future__ import annotations
 
+import io
 import os
 import pickle
+from contextlib import ExitStack
 
+import pytest
 from _pytest.fixtures import FixtureDef
 from _pytest.fixtures import SubRequest
+
+
+def _restore_tmp_path_factory(state: dict) -> pytest.TempPathFactory:
+    """Recreates a ``TempPathFactory`` from its pickled state."""
+    factory = pytest.TempPathFactory.__new__(pytest.TempPathFactory)
+    factory.__dict__.update(state)
+    # Cleanup of the base temp directory stays with the session which created
+    # it; a restored factory only needs an empty stack to be operational.
+    factory._exit_stack = ExitStack()  # pylint: disable=protected-access
+    return factory
+
+
+class _CachePickler(pickle.Pickler):
+    """Pickler which knows how to serialize Pytest's ``TempPathFactory``."""
+
+    def reducer_override(self, obj):
+        if isinstance(obj, pytest.TempPathFactory):
+            state = {name: value for name, value in obj.__dict__.items() if name != "_exit_stack"}
+            return _restore_tmp_path_factory, (state,)
+        return NotImplemented
+
+
+def _dumps(obj) -> bytes:
+    """Pickles ``obj`` with the fixture-result recipes of ``_CachePickler``."""
+    buffer = io.BytesIO()
+    _CachePickler(buffer).dump(obj)
+    return buffer.getvalue()
 
 
 def _load_fixture_result(fixturedef: FixtureDef, request: SubRequest):
@@ -35,12 +65,11 @@ def _cache_fixture_result(fixturedef: FixtureDef, request: SubRequest):
         if not os.path.isfile(cache_file_path):
             res = fixturedef.cached_result[0]
             try:
-                payload = pickle.dumps(res)
+                payload = _dumps(res)
 
-            # Pickling failures are not confined to pickle.PicklingError: Pytest's own
-            # tmp_path_factory raises AttributeError since Pytest 9.1, locks and open
-            # files raise TypeError, and a custom __reduce__ may raise anything at all.
-            # A fixture that cannot be cached must never fail the test run.
+            # Pickling failures are not confined to pickle.PicklingError: locks and
+            # open files raise TypeError, and a custom __reduce__ may raise anything
+            # at all. A fixture that cannot be cached must never fail the test run.
             except Exception:  # pylint: disable=broad-exception-caught
                 return  # skip caching; the fixture is re-evaluated in each subsession
 

--- a/src/pytest_isolate_mpi/_fixturecache.py
+++ b/src/pytest_isolate_mpi/_fixturecache.py
@@ -49,7 +49,7 @@ def _load_fixture_result(fixturedef: FixtureDef, request: SubRequest):
             try:
                 with open(cache_file_path, mode="rb") as f:
                     res = pickle.load(f)
-            except (EOFError, pickle.UnpicklingError):
+            except Exception:  # pylint: disable=broad-exception-caught
                 # ignore old corrupted files and re-evaluate the
                 # fixture rather than failing the test.
                 return None

--- a/src/pytest_isolate_mpi/_fixturecache.py
+++ b/src/pytest_isolate_mpi/_fixturecache.py
@@ -49,6 +49,9 @@ def _load_fixture_result(fixturedef: FixtureDef, request: SubRequest):
             try:
                 with open(cache_file_path, mode="rb") as f:
                     res = pickle.load(f)
+            # Unpickling runs arbitrary ``__setstate__``/``__reduce__`` code of the
+            # cached objects, so a corrupt or stale file can surface as any
+            # exception type, not just ``EOFError``/``UnpicklingError``.
             except Exception:  # pylint: disable=broad-exception-caught
                 # ignore old corrupted files and re-evaluate the
                 # fixture rather than failing the test.
@@ -68,6 +71,9 @@ def _cache_fixture_result(fixturedef: FixtureDef, request: SubRequest):
                 payload = _pickle_dumps(res)
 
             # A fixture that cannot be cached must never fail the test run.
+            # Pickling calls arbitrary ``__reduce__``/``__getstate__`` code of the
+            # fixture result, which may raise anything (``TypeError``,
+            # ``AttributeError``, ``RecursionError``, ...) besides ``PicklingError``.
             except Exception:  # pylint: disable=broad-exception-caught
                 return  # skip caching; the fixture is re-evaluated in each subsession
 

--- a/src/pytest_isolate_mpi/_fixturecache.py
+++ b/src/pytest_isolate_mpi/_fixturecache.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import os
 import pickle
+import tempfile
 
 from _pytest.fixtures import FixtureDef
 from _pytest.fixtures import SubRequest
@@ -16,8 +17,13 @@ def _load_fixture_result(fixturedef: FixtureDef, request: SubRequest):
     if fixturedef.scope == "session" and fixturedef.argname != "comm":
         cache_file_path = _get_cache_file_path(fixturedef, request)
         if os.path.isfile(cache_file_path):
-            with open(cache_file_path, mode="rb") as f:
-                res = pickle.load(f)
+            try:
+                with open(cache_file_path, mode="rb") as f:
+                    res = pickle.load(f)
+            except (EOFError, pickle.UnpicklingError):
+                # ignore old corrupted files and re-evaluate the
+                # fixture rather than failing the test.
+                return None
             fixturedef.cached_result = (res, None, None)
             return True  # cache is loaded, do not call the fixture function
     return None  # continue calling the fixture function
@@ -28,10 +34,26 @@ def _cache_fixture_result(fixturedef: FixtureDef, request: SubRequest):
     if fixturedef.scope == "session" and fixturedef.argname != "comm":
         cache_file_path = _get_cache_file_path(fixturedef, request)
         if not os.path.isfile(cache_file_path):
-            os.makedirs(os.path.dirname(cache_file_path), exist_ok=True)  # pylint: disable=consider-using-with
-            with open(cache_file_path, mode="wb") as f:
-                res = fixturedef.cached_result[0]
-                pickle.dump(res, f)
+            res = fixturedef.cached_result[0]
+            try:
+                payload = pickle.dumps(res)
+
+            # tmp_path_factory (>= 9.1), locks, open files, lambdas, ... aren't picklable.
+            except (pickle.PicklingError, AttributeError, TypeError):
+                return  # skip caching; the fixture is re-evaluated in each subsession
+
+            cache_dir = os.path.dirname(cache_file_path)
+            os.makedirs(cache_dir, exist_ok=True)
+            fd, tmp_path = tempfile.mkstemp(dir=cache_dir)
+            try:
+                with os.fdopen(fd, mode="wb") as f:
+                    f.write(payload)
+                os.replace(tmp_path, cache_file_path)
+            except BaseException:  # pylint: disable=broad-exception-caught
+                # Remove the temporary file on any error so we never leave a stray file behind.
+                if os.path.isfile(tmp_path):
+                    os.remove(tmp_path)
+                raise
 
 
 def _get_cache_file_path(fixturedef: FixtureDef, request: SubRequest) -> str:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -39,6 +39,7 @@ import pytest
         pytest.param("test_session_scoped_fixtures", {"passed": 36}, [], id="test_cache"),
         pytest.param("test_omp_num_threads", {"passed": 3}, [], id="test_omp_num_threads"),
         pytest.param("test_unpicklable_session_fixture", {"passed": 4}, [], id="test_unpicklable_session_fixture"),
+        pytest.param("test_tmp_path_factory_cached", {"passed": 4}, [], id="test_tmp_path_factory_cached"),
     ],
 )
 def test_outcomes(pytester, test, outcomes, lines):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -35,6 +35,12 @@ import pytest
         pytest.param("test_mpi_tmp_path", {"passed": 2}, [], id="test_mpi_tmp_path"),
         pytest.param("test_no_mpi", {"passed": 1}, [], id="test_no_mpi"),
         pytest.param("test_session_scoped_fixtures", {"passed": 36}, [], id="test_cache"),
+        pytest.param(
+            "test_unpicklable_session_fixture",
+            {"passed": 4},
+            [],
+            id="test_unpicklable_session_fixture",
+        ),
     ],
 )
 def test_outcomes(pytester, test, outcomes, lines):


### PR DESCRIPTION
## Summary

Under **pytest ≥ 9.1**, any MPI test that uses `tmp_path` crashes in the session-fixture cache:

```
AttributeError: Can't get local object '_BaseExitStack._create_cb_wrapper.<locals>._exit_wrapper'
...
EOFError: Ran out of input
```

This PR fixes the crash, restores pytest ≥ 9.1 compatibility, and makes the fixture cache robust against any unpicklable session fixture. Pytest's own `tmp_path_factory` keeps being cached: it is serialized with a dedicated pickling recipe, so all subsessions share one base temp directory exactly as before pytest 9.1.

## Root cause

The plugin shares session-scoped fixture results across the forked MPI subsessions by pickling them to disk. pytest 9.1 gave `TempPathFactory` (the value of `tmp_path_factory`) an instance-level `contextlib.ExitStack` for temp-dir cleanup; its callbacks are nested closures, which pickle cannot serialize by qualified name, so pickling now raises `AttributeError`. The cascade made it worse: the cache file was opened *before* `pickle.dump`, so the failed dump left a 0-byte file behind and every later subsession failed loading it with `EOFError` — one unpicklable fixture poisoned the whole run.

## Changes

**`_fixturecache.py`:**

- Serialize first; if a fixture result can't be pickled, skip caching it instead of crashing. Pickling failures surface as arbitrary exception types — `TypeError` for locks, `AttributeError` in the pytest 9.1 case, anything from a custom `__reduce__` — not just `pickle.PicklingError`, so the catch is deliberately broad. Since serialization happens before the cache file is opened, a failed dump can no longer leave a 0-byte file behind.
- On load, treat any failure to read back a cache file as a cache miss and re-evaluate the fixture; unpickling a corrupt file can likewise raise nearly anything.
- Keep caching `tmp_path_factory`: a custom pickler serializes `TempPathFactory` without its process-local `_exit_stack` and recreates the stack empty on load. Cleanup of the base temp directory stays with the session that created it — the same contract as before pytest 9.1. On pytest < 9.1 the recipe degrades to plain pickling.

**Regression tests** — `examples/test_unpicklable_session_fixture.py` (session fixture returning a `threading.Lock`, unpicklable on *every* pytest version) pins the skip-and-re-evaluate fallback; it reproduced the `EOFError` cascade on `main`. `examples/test_tmp_path_factory_cached.py` pins the cached path: a later subsession only sees marker files under `tmp_path_factory.getbasetemp()` if the factory was restored from the cache. Both are wired into `tests/test_examples.py`.

**CI & metadata** — pytest `9.0` and `9.1` added to the test matrix; Python `3.9` dropped, since pytest ≥ 9.0 requires Python ≥ 3.10. Accordingly, `requires-python` is raised to `>=3.10` and the pytest dependency floor to `>= 7.3`, so the package metadata matches what CI actually tests.

**Documentation & changelog** — the *Fixture Scopes* section of `docs/usage.rst` now documents the contract: `tmp_path_factory` is cached via a dedicated recipe so all sub sessions share one base temp directory, while any other session fixture whose result cannot be pickled is skipped, re-evaluated per sub session like `comm`, and thus effectively function-scoped. Changelog entries under Version 0.4.

## Behaviour change

Session-scoped fixtures whose result cannot be pickled are re-evaluated in each subsession (like `comm`) instead of being shared. `tmp_path_factory` is explicitly **not** in this category thanks to the pickling recipe. Picklable session fixtures are cached exactly as before (`examples/test_session_scoped_fixtures.py` still asserts `was_cached is True`).
