### PR TITLE
Add support for OpenMP thread configuration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@ Changelog
 
 Version 0.4
 -----------
+- The ``mpi`` marker now accepts an optional ``threads`` argument. 
+  When set, ``OMP_NUM_THREADS`` is configured for each isolated MPI process.
 
 - Two command line options for the use of independent Python executables
   and Pytest configurations in the main session and subsessions have

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -43,6 +43,33 @@ This test will always fail an MPI process 0:
 All tests not marked with the ``mpi`` mark are executed as usual in the
 main ``pytest`` session.
 
+Controlling OpenMP threads
+--------------------------
+
+The number o OpenMP threads used by each MPI process can be set with the
+optional ``threads`` argument of the ``mpi`` mark:
+
+.. code-block:: python
+
+    import os 
+
+    import pytest
+
+    @pytest.mark.mpi(ranks=2, threads=4)
+    def test_hybrid_parallel_code(mpi_ranks):
+        assert os.environ["OMP_NUM_THREADS"] =="4"
+
+For this example, ``pytest-isolate-mpi`` launches two MPI processes and sets
+``OMP_NUM_THREADS=4`` in each process.
+
+The ``threads`` argument must be a positive integer. If it is omitted,
+``pytest-isolate-mpi`` does not modify ``OMP_NUM_THREADS`` and the value
+is inherited from the parent environment.
+
+The option only applies to isolated MPI test subprocesses. It does not modify
+the environment of the main Pytest process when MPI isolation is disabled.
+
+
 Parametrizing the Number of MPI Processes
 -----------------------------------------
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -46,7 +46,7 @@ main ``pytest`` session.
 Controlling OpenMP threads
 --------------------------
 
-The number o OpenMP threads used by each MPI process can be set with the
+The number of OpenMP threads used by each MPI process can be set with the
 optional ``threads`` argument of the ``mpi`` mark:
 
 .. code-block:: python

--- a/examples/test_omp_num_threads.py
+++ b/examples/test_omp_num_threads.py
@@ -1,0 +1,15 @@
+import os
+
+import pytest
+
+
+@pytest.mark.mpi(ranks=2, threads=4)
+def test_omp_num_threads(mpi_ranks):
+    assert mpi_ranks == 2
+    assert os.environ["OMP_NUM_THREADS"] == "4"
+
+
+@pytest.mark.mpi(ranks=1, threads=1)
+def test_single_omp_thread(mpi_ranks):
+    assert mpi_ranks == 1
+    assert os.environ["OMP_NUM_THREADS"] == "1"

--- a/src/pytest_isolate_mpi/_constants.py
+++ b/src/pytest_isolate_mpi/_constants.py
@@ -19,6 +19,7 @@ NO_MPI_ISOLATION_ARG = "--no-mpi-isolation"
 MPI_DEFAULT_TEST_TIMEOUT_ARG = "--mpi-default-test-timeout"
 MPI_DEFAULT_TEST_TIMEOUT_UNIT_ARG = "--mpi-default-test-timeout-unit"
 ENVIRONMENT_VARIABLE_TO_HIDE_INNARDS_OF_PLUGIN = "PYTEST_ISOLATE_MPI_IS_FORKED"
+OMP_NUM_THREADS_ENV = "OMP_NUM_THREADS"
 TIME_UNIT_CONVERSION = {
     "s": lambda timeout: timeout,
     "m": lambda timeout: timeout * 60,

--- a/src/pytest_isolate_mpi/_plugin.py
+++ b/src/pytest_isolate_mpi/_plugin.py
@@ -27,6 +27,7 @@ from ._constants import MPI_ENV_HINTS
 from ._constants import NO_MPI_ISOLATION_ARG
 from ._constants import TIME_UNIT_CONVERSION
 from ._constants import VERBOSE_MPI_ARG
+from ._constants import OMP_NUM_THREADS_ENV
 from ._fixturecache import _load_fixture_result
 from ._fixturecache import _cache_fixture_result
 from .fixtures import comm_fixture  # pylint: disable=unused-import
@@ -120,6 +121,14 @@ class MPIPlugin:
     def pytest_generate_tests(self, metafunc):
         """Extend the marker @pytest.mark.mpi such that we have parametrization of the tests w.r.t. # ranks."""
         for mark in metafunc.definition.iter_markers(name="mpi"):
+            threads = mark.kwargs.get("threads")
+
+            if threads is not None:
+                if type(threads) is not int or threads <= 0:
+                    pytest.exit(
+                        "Numer of OpenMP threads must be a positive integer",
+                        pytest.ExitCode.USAGE_ERROR,
+                    )
             ranks = mark.kwargs.get("ranks")
             if ranks is not None:
                 if isinstance(ranks, collections.abc.Sequence):
@@ -205,6 +214,8 @@ class MPIPlugin:
 
     def _mpi_runtestprotocol(self, item):  # pylint: disable=too-many-locals,too-many-branches
         mpi_ranks = 1
+        threads = None
+
         for fixture in item.fixturenames:
             if fixture == "mpi_ranks" and "mpi_ranks" in item.callspec.params:
                 mpi_ranks = item.callspec.params["mpi_ranks"]
@@ -212,6 +223,8 @@ class MPIPlugin:
         timeout = None
         timeout_in = ("NaN", "N/A")
         for mark in item.iter_markers(name="mpi"):
+            threads = mark.kwargs.get("threads")
+
             timeout = mark.kwargs.get("timeout", self._mpi_default_test_timeout)
             if timeout is not None:
                 unit = mark.kwargs.get("unit", self._mpi_default_test_timeout_unit)
@@ -234,6 +247,8 @@ class MPIPlugin:
             run_env = os.environ.copy()
             run_env[ENVIRONMENT_VARIABLE_TO_HIDE_INNARDS_OF_PLUGIN] = "1"
             run_env["PYTEST_MPI_REPORTS_PATH"] = tmpdir
+            if threads is not None:
+                run_env[OMP_NUM_THREADS_ENV] = str(threads)
 
             try:
                 # FIXME: disable capturing if -s is passed to pytest

--- a/src/pytest_isolate_mpi/_plugin.py
+++ b/src/pytest_isolate_mpi/_plugin.py
@@ -126,7 +126,7 @@ class MPIPlugin:
             if threads is not None:
                 if type(threads) is not int or threads <= 0:
                     pytest.exit(
-                        "Numer of OpenMP threads must be a positive integer",
+                        "Number of OpenMP threads must be a positive integer",
                         pytest.ExitCode.USAGE_ERROR,
                     )
             ranks = mark.kwargs.get("ranks")

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 
@@ -35,6 +37,7 @@ import pytest
         pytest.param("test_mpi_tmp_path", {"passed": 2}, [], id="test_mpi_tmp_path"),
         pytest.param("test_no_mpi", {"passed": 1}, [], id="test_no_mpi"),
         pytest.param("test_session_scoped_fixtures", {"passed": 36}, [], id="test_cache"),
+        pytest.param("test_omp_num_threads", {"passed": 3}, [], id="test_omp_num_threads"),
     ],
 )
 def test_outcomes(pytester, test, outcomes, lines):
@@ -75,3 +78,51 @@ def test_outcomes_no_isolation(pytester, test, outcomes, lines):
     result.assert_outcomes(**outcomes)
     if lines:
         result.stdout.re_match_lines(lines, consecutive=True)
+
+
+@pytest.mark.parametrize(
+    "threads",
+    [
+        pytest.param("0", id="zero"),
+        pytest.param("-1", id="negative"),
+        pytest.param("2.5", id="float"),
+        pytest.param("'4'", id="string"),
+        pytest.param("True", id="boolean"),
+    ],
+)
+def test_invalid_thread_count(pytester, threads):
+    pytester.makepyfile(f"""
+        import pytest
+
+        @pytest.mark.mpi(ranks=2, threads={threads})
+        def test_invalid_threads(mpi_ranks):
+            assert True
+        """)
+
+    result = pytester.runpytest("-v")
+    combined_output = result.stdout.str() + result.stderr.str()
+
+    assert result.ret != pytest.ExitCode.OK
+    assert "Numer of OpenMP threads must be a positive integer" in combined_output
+
+
+def test_thread_count_does_not_modify_outer_environ(
+    pytester,
+    monkeypatch,
+):
+    monkeypatch.setenv("OMP_NUM_THREADS", "9")
+
+    pytester.makepyfile("""
+        import os
+
+        import pytest
+
+        @pytest.mark.mpi(ranks=2, threads=3)
+        def test_inner_environ(mpi_ranks):
+            assert os.environ["OMP_NUM_THREADS"] == "3"
+        """)
+
+    result = pytester.runpytest("-v")
+
+    result.assert_outcomes(passed=2)
+    assert os.environ["OMP_NUM_THREADS"] == "9"

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -103,7 +103,7 @@ def test_invalid_thread_count(pytester, threads):
     combined_output = result.stdout.str() + result.stderr.str()
 
     assert result.ret != pytest.ExitCode.OK
-    assert "Numer of OpenMP threads must be a positive integer" in combined_output
+    assert "Number of OpenMP threads must be a positive integer" in combined_output
 
 
 def test_thread_count_does_not_modify_outer_environ(


### PR DESCRIPTION
## Summary

Add support for configuring the number of OpenMP threads through the existing `pytest.mark.mpi` marker.

Example:

```python
@pytest.mark.mpi(ranks=2, threads=4)
def test_example():
    ...
```

## Changes

- add the optional `threads` marker argument
- validate that `threads` is a positive integer
- set `OMP_NUM_THREADS` for MPI suvprocesses
- add tests for the new functionality and validation
- update the documentation and changelog

## Testing

```bash
make test
make lint
make docs
```